### PR TITLE
ニュースレターが直訳だったので、メールマガジンに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -1045,7 +1045,7 @@
 						</div>
 						<div class="footer-right">
 							<div class="newsletter-widget">
-								<h4>ニュースレター</h4>
+								<h4>メールマガジン</h4>
 								<p>また行っのは機会はあるがいませ、だから孤独自由た発展方で自分の弟の聴いん自由た事が学校に起らばなりう他へ、も</p>
 								<div class="form">
 									<p class="subscribe_success" id="subscribe_success" style="display:none;"></p>


### PR DESCRIPTION
ニュースレターは、日本では、メルマガの方が馴染みがあるので、こちらに変更したほうが良いと思います。